### PR TITLE
Added support for fallback directories

### DIFF
--- a/src/Dflydev/Psr0ResourceLocator/AbstractPsr0ResourceLocator.php
+++ b/src/Dflydev/Psr0ResourceLocator/AbstractPsr0ResourceLocator.php
@@ -107,7 +107,7 @@ abstract class AbstractPsr0ResourceLocator implements Psr0ResourceLocatorInterfa
 
         $directories = array();
         foreach ($this->map as $namespace => $dirs) {
-            if (0 === strpos($namespaceish, $namespace)) {
+            if ($namespace == "" || 0 === strpos($namespaceish, $namespace)) {
                 foreach ($dirs as $dir) {
                     if (is_dir($directory = $dir.'/'.$searchPath)) {
                         $directories[] = $directory;


### PR DESCRIPTION
Empty namespaces will now be handled as well. An example is Composer fallback directories, implemented in `ComposerResourceLocator`, see https://github.com/dflydev/dflydev-psr0-resource-locator-composer/pull/2.
